### PR TITLE
Set default host for Rails API in test environment

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -84,11 +84,12 @@ jobs:
 
       - name: Run Rspec Tests
         run: |
-          if [ -f "tmp/parallel_runtime_rspec.log" ]; then
-            bundle exec parallel_rspec -n 4 --group-by runtime --only-group ${{ matrix.group }} --verbose
-          else
+          # if [ -f "tmp/parallel_runtime_rspec.log" ] && [ $(wc -l < tmp/parallel_runtime_rspec.log) -gt 50 ]; then
+            # bundle exec parallel_rspec -n 4 --group-by runtime --only-group ${{ matrix.group }} --verbose
+          # else
+            # echo "Runtime log file is missing or too small, falling back to filesize grouping."
             bundle exec parallel_rspec -n 4 --group-by filesize --only-group ${{ matrix.group }} --verbose
-          fi
+          # fi
 
         env:
           AUTH_SECRET: ${{ secrets.AUTH_SECRET}}

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -21,6 +21,8 @@ dictionaries:
 words:
   - autobuild
   - bytesize
+  - fcontext
+  - fdescribe
   - filesize
   - invalidcookie
   - isready
@@ -32,6 +34,7 @@ words:
   - rowan
   - rsa
   - Rswag
+  - srand
   - swag
   - timestr
   - unsubscription

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require "factory_bot_rails"
 # require_relative 'support/openapi_helper'
 ENV["RAILS_ENV"] = "test"
 ENV["AUTH_SECRET"] = "test_secret"
+ENV[RAILS_API_DEFAULT_HOST] ||= "http://localhost:3000/api/v1"
 
 require "simplecov"
 require "simplecov-console"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require "factory_bot_rails"
 # require_relative 'support/openapi_helper'
 ENV["RAILS_ENV"] = "test"
 ENV["AUTH_SECRET"] = "test_secret"
-ENV[RAILS_API_DEFAULT_HOST] ||= "http://localhost:3000/api/v1"
+ENV["RAILS_API_DEFAULT_HOST"] ||= "http://localhost:3000/api/v1"
 
 require "simplecov"
 require "simplecov-console"


### PR DESCRIPTION
Configure the default host for the Rails API to ensure proper routing during tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Introduced a default host environment variable for the Rails API in the test setup, improving configuration for test environments.
	- Updated the spell checker configuration to recognize new custom words, enhancing spell-checking accuracy.
	- Simplified the RSpec test execution logic in the CI workflow by removing conditional checks, ensuring consistent test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->