### PR TITLE
Implement organization search with fuzzy matching

### DIFF
--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: streetsidesoftware/cspell-action@v6
         with:
           # Inline PR comments instead of annotations
-          inline: error
+          inline: warning
           # Fail on warnings
           strict: true
           # Show progress

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -21,14 +21,15 @@ module Api
         authorize ::Organization, :index?
 
         @objects = if params[:query].present?
-                     query = "%#{params[:query]}%"
+                     query = params[:query].to_s.strip
+                     query = "%#{ActiveRecord::Base.sanitize_sql_like(query)}%"
                      ::Organization.where("name ILIKE ? OR slug ILIKE ?", query, query)
               else
                 ::Organization.all
               end
 
         @objects = @objects.order(name: :asc)
-        @objects = @objects.page(1).per(10000)
+        @objects = @objects.page(1).per(1000)
 
         render json: {
           data: @objects&.map { |object| index_serializer.new(object).attributes },

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -20,12 +20,12 @@ module Api
       def index
         authorize ::Organization, :index?
 
-        @objects = if params[:query].present?
-          query = "%#{params[:query]}%"
-          @objects.where("name ILIKE ? OR slug ILIKE ?", query, query)
-        else
-          ::Organization.all
-        end
+        @objects  = if params[:query].present?
+                      query = "%#{params[:query]}%"
+                      ::Organization.where("name ILIKE ? OR slug ILIKE ?", query, query)
+                    else
+                      ::Organization.all
+                    end
 
         @objects = @objects.order(name: :asc)
         @objects = @objects.page(1).per(10000)

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -20,9 +20,16 @@ module Api
       def index
         authorize ::Organization, :index?
 
-        @objects = ::Organization.all
+        @objects = if params[:query].present?
+          query = "%#{params[:query]}%"
+          @objects.where("name ILIKE ? OR slug ILIKE ?", query, query)
+        else
+          ::Organization.all
+        end
+
         @objects = @objects.order(name: :asc)
         @objects = @objects.page(1).per(10000)
+
         render json: {
           data: @objects&.map { |object| index_serializer.new(object).attributes },
           meta: {
@@ -33,7 +40,6 @@ module Api
             total_count: @objects.total_count
           }
         }, status: :ok
-
       end
 
       def staff

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -20,13 +20,13 @@ module Api
       def index
         authorize ::Organization, :index?
 
-        @objects = if params[:query].present?
-                     query = params[:query].to_s.strip
+        query = params[:query].to_s.strip
+        @objects = if query.present?
                      query = "%#{ActiveRecord::Base.sanitize_sql_like(query)}%"
                      ::Organization.where("name ILIKE ? OR slug ILIKE ?", query, query)
-              else
-                ::Organization.all
-              end
+                   else
+                     ::Organization.all
+                   end
 
         @objects = @objects.order(name: :asc)
         @objects = @objects.page(1).per(1000)

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -21,8 +21,8 @@ module Api
         authorize ::Organization, :index?
 
         @objects = if params[:query].present?
-                query = "%#{params[:query]}%"
-                ::Organization.where("name ILIKE ? OR slug ILIKE ?", query, query)
+                     query = "%#{params[:query]}%"
+                     ::Organization.where("name ILIKE ? OR slug ILIKE ?", query, query)
               else
                 ::Organization.all
               end

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -20,12 +20,12 @@ module Api
       def index
         authorize ::Organization, :index?
 
-        @objects  = if params[:query].present?
-                      query = "%#{params[:query]}%"
-                      ::Organization.where("name ILIKE ? OR slug ILIKE ?", query, query)
-                    else
-                      ::Organization.all
-                    end
+        @objects = if params[:query].present?
+                query = "%#{params[:query]}%"
+                ::Organization.where("name ILIKE ? OR slug ILIKE ?", query, query)
+              else
+                ::Organization.all
+              end
 
         @objects = @objects.order(name: :asc)
         @objects = @objects.page(1).per(10000)

--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -1,3 +1,0 @@
-Rswag::Ui.configure do |c|
-  c.openapi_endpoint "/api-docs/v1/openapi.yaml", "API V1 Docs"
-end

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -24,6 +24,7 @@ words:
   - fcontext
   - fdescribe
   - filesize
+  - ILIKE
   - invalidcookie
   - isready
   - mikepenz

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -40,5 +40,6 @@ words:
   - timestr
   - unsubscription
   - VERCEL
+  - teamlists
 ignoreWords: []
 import: []

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -41,5 +41,8 @@ words:
   - unsubscription
   - VERCEL
   - teamlists
+  - tera
+  - pokepaste
+  - swaggerize
 ignoreWords: []
 import: []

--- a/db/migrate/20241201223731_add_pg_trgm_extension_and_indexes.rb
+++ b/db/migrate/20241201223731_add_pg_trgm_extension_and_indexes.rb
@@ -1,7 +1,7 @@
 class AddPgTrgmExtensionAndIndexes < ActiveRecord::Migration[7.2]
   def change
     # Enable the pg_trgm extension
-    enable_extension 'pg_trgm'
+    enable_extension "pg_trgm"
 
     # Remove existing indexes if they exist
     remove_index :organizations, :name if index_exists?(:organizations, :name)
@@ -12,7 +12,7 @@ class AddPgTrgmExtensionAndIndexes < ActiveRecord::Migration[7.2]
     add_index :organizations, :slug, unique: true
 
     # Add GIN indexes for fuzzy search with unique names
-    add_index :organizations, :name, using: :gin, opclass: :gin_trgm_ops, name: 'index_organizations_on_name_trgm'
-    add_index :organizations, :slug, using: :gin, opclass: :gin_trgm_ops, name: 'index_organizations_on_slug_trgm'
+    add_index :organizations, :name, using: :gin, opclass: :gin_trgm_ops, name: "index_organizations_on_name_trgm"
+    add_index :organizations, :slug, using: :gin, opclass: :gin_trgm_ops, name: "index_organizations_on_slug_trgm"
   end
 end

--- a/db/migrate/20241201223731_add_pg_trgm_extension_and_indexes.rb
+++ b/db/migrate/20241201223731_add_pg_trgm_extension_and_indexes.rb
@@ -1,0 +1,18 @@
+class AddPgTrgmExtensionAndIndexes < ActiveRecord::Migration[7.2]
+  def change
+    # Enable the pg_trgm extension
+    enable_extension 'pg_trgm'
+
+    # Remove existing indexes if they exist
+    remove_index :organizations, :name if index_exists?(:organizations, :name)
+    remove_index :organizations, :slug if index_exists?(:organizations, :slug)
+
+    # Add unique B-tree indexes to enforce uniqueness
+    add_index :organizations, :name, unique: true
+    add_index :organizations, :slug, unique: true
+
+    # Add GIN indexes for fuzzy search with unique names
+    add_index :organizations, :name, using: :gin, opclass: :gin_trgm_ops, name: 'index_organizations_on_name_trgm'
+    add_index :organizations, :slug, using: :gin, opclass: :gin_trgm_ops, name: 'index_organizations_on_slug_trgm'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_27_221646) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_01_223731) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
@@ -144,10 +145,12 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_27_221646) do
     t.string "slug"
     t.bigint "limitless_org_id"
     t.bigint "owner_id"
-    t.index ["name"], name: "index_organizations_on_name", unique: true, where: "(name IS NOT NULL)"
+    t.index ["name"], name: "index_organizations_on_name", unique: true
+    t.index ["name"], name: "index_organizations_on_name_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["owner_id"], name: "index_organizations_on_owner_id"
     t.index ["partner"], name: "index_organizations_on_partner"
     t.index ["slug"], name: "index_organizations_on_slug", unique: true
+    t.index ["slug"], name: "index_organizations_on_slug_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "phase_players", force: :cascade do |t|

--- a/openapi/v1/openapi.yaml
+++ b/openapi/v1/openapi.yaml
@@ -35,7 +35,12 @@ paths:
       - Accounts
       description: Creates a new Account.
       operationId: postAccount
-      parameters: []
+      parameters:
+      - name: username
+        in: query
+        description: Username
+        schema:
+          type: string
       security:
       - Bearer: []
       responses:
@@ -516,24 +521,32 @@ paths:
       - name: page
         in: query
         description: Page number for pagination
-        required: true
+        required: false
         schema:
           type: integer
       - name: per_page
         in: query
         description: Number of items per page for pagination
-        required: true
+        required: false
         schema:
           type: integer
       - name: partner
         in: query
+        required: false
+        description: Filter by partner organizations
         schema:
           type: boolean
+      - name: query
+        in: query
+        description: Search query
+        required: false
+        schema:
+          type: string
       security:
       - Bearer: []
       responses:
         '200':
-          description: successful
+          description: Search Organizations
           content:
             application/json:
               schema:
@@ -948,7 +961,7 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/PlayerDetails"
-        '422':
+        '409':
           description: Already registered
           content:
             application/json:
@@ -1235,13 +1248,13 @@ paths:
       - name: page
         in: query
         description: Page number for pagination
-        required: true
+        required: false
         schema:
           type: integer
       - name: per_page
         in: query
         description: Number of items per page for pagination
-        required: true
+        required: false
         schema:
           type: integer
       security:
@@ -1329,7 +1342,7 @@ paths:
         '404':
           description: not found
 servers:
-- url: https://api.battlestadium.gg/api/v1
+- url: http://localhost:3000/api/v1
 components:
   responses:
     NotFound:
@@ -1345,14 +1358,14 @@ components:
       name: page
       in: query
       description: Page number for pagination
-      required: true
+      required: false
       schema:
         type: integer
     PerPage:
       name: per_page
       in: query
       description: Number of items per page for pagination
-      required: true
+      required: false
       schema:
         type: integer
     VercelTokenHeader:

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -499,7 +499,7 @@ PAGE_PARAMETER = {
   in: :query,
   type: :integer,
   description: "Page number for pagination",
-  required: true,
+  required: false,
 }
 
 PER_PAGE_PARAMETER = {
@@ -507,7 +507,7 @@ PER_PAGE_PARAMETER = {
   in: :query,
   type: :integer,
   description: "Number of items per page for pagination",
-  required: true,
+  required: false,
 }
 
 PAGINATION_RESPONSE = {


### PR DESCRIPTION
Introduce a search feature for organizations using a simple where clause and fuzzy matching with the pg_trgm extension. This enhances the ability to find organizations by name or slug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced search functionality in the organizations index, allowing users to filter results based on a query parameter.
	- Pagination limit adjusted to 1,000 entries per page for better performance.
	- Updated API documentation to reflect new search capabilities for the organizations endpoint.
	- Added new required `username` parameter for the accounts endpoint.

- **Bug Fixes**
	- Improved error handling for the staff action, ensuring consistent responses for not found errors.

- **Chores**
	- Added `ILIKE`, `teamlists`, `tera`, `pokepaste`, and `swaggerize` to the recognized words in the spell check configuration.
	- Enabled PostgreSQL `pg_trgm` extension for improved text search capabilities.
	- Removed configuration for Rswag UI, affecting API documentation access.
	- Updated spell check workflow to report issues as warnings instead of errors.
	- Made pagination parameters optional in API requests for greater flexibility.
	- Updated server URL in the OpenAPI specification for local development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->