### PR TITLE
Add option to skip data seeding with environment variable

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,7 @@ early_access: true
 enable_free_tier: true
 tone_instructions: "You must use a casual yet friendly tone in your writing."
 reviews:
-  profile: "assertive"
+  profile: "chill"
   request_changes_workflow: true
   high_level_summary: true
   poem: false

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -44,5 +44,14 @@ words:
   - tera
   - pokepaste
   - swaggerize
+  - thatguyinabeanie
+  - Escobar
+  - Fuecoco
+  - Butterfree
+  - Clefable
+  - Victreebel
+  - Sandslash
+  - Staryu
+  - deepcode
 ignoreWords: []
 import: []

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,11 @@ if Rails.env.production?
   exit
 end
 
+if ENV.fetch("SKIP_SEEDS", false) == "true"
+  puts("Skipping seeding data.")
+  exit
+end
+
 puts("Seeding data...")
 PokemonTeam.reset_column_information
 Organization.reset_column_information


### PR DESCRIPTION
Introduce the ability to skip data seeding by using the `SKIP_SEEDS` environment variable, allowing for more flexible data management during setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the review tone from "assertive" to "chill" for a more relaxed feedback style.
	- Added new words to the spell-check configuration for improved accuracy.
	- Introduced a conditional check to skip data seeding based on an environment variable.

- **Bug Fixes**
	- None

- **Documentation**
	- None

- **Refactor**
	- None

- **Style**
	- None

- **Tests**
	- None

- **Chores**
	- None

- **Revert**
	- None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->