### PR TITLE
Update linting configuration and enforce name constraint in phases table

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": false,
   "editor.bracketPairColorization.independentColorPoolPerBracketType": true,
-  "editor.defaultColorDecorators": true,
+  "editor.defaultColorDecorators": "auto",
   "editor.inlayHints.padding": true,
 
   "sonarlint.connectedMode.project": {

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -53,5 +53,9 @@ words:
   - Sandslash
   - Staryu
   - deepcode
+  - logpanel
+  - jacoco
+  - sqltools
+  - sonarlint
 ignoreWords: []
 import: []

--- a/db/migrate/20241206194112_change_name_null_constraint_in_phases.rb
+++ b/db/migrate/20241206194112_change_name_null_constraint_in_phases.rb
@@ -1,0 +1,5 @@
+class ChangeNameNullConstraintInPhases < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :phases, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_02_150406) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_06_194112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "pgcrypto"
@@ -168,7 +168,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_02_150406) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "type", null: false
-    t.string "name"
+    t.string "name", null: false
     t.integer "best_of", default: 3, null: false
     t.datetime "started_at"
     t.datetime "ended_at"


### PR DESCRIPTION
Adjust the linting settings for better code formatting and implement a migration to enforce a non-null constraint on the name column in the phases table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated editor settings for improved color decorator functionality.
	- Enforced a NOT NULL constraint on the `name` field in the phases table to enhance data integrity.
	- Expanded spell checker vocabulary with new terms: `logpanel`, `jacoco`, `sqltools`, and `sonarlint`.

- **Bug Fixes**
	- Removed duplicate entries in the `rubyTestExplorer` settings for clarity.

- **Documentation**
	- Updated schema version to reflect recent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->