### PR TITLE
Allow seeding in production with environment variable adjustment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.action_cable.mount_path = nil
   config.action_cable.url = ENV["ACTION_CABLE_URL"]
 
-  config.action_cable.allowed_request_origins = ENV["ACTION_CABLE_ALLOWED_ORIGINS"].split(",")
+  config.action_cable.allowed_request_origins = ENV["ACTION_CABLE_ALLOWED_ORIGINS"]&.split(",")
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@
 require "faker"
 
 if ENV.fetch("SKIP_SEEDS", "false") == "true"
-  puts("Skipping seeding data.")
+  puts("Skip seeding. Exiting...")
   exit
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,7 @@
 
 require "faker"
 
-if ENV.fetch("SKIP_SEEDS", false) == "true"
+if ENV.fetch("SKIP_SEEDS", "false") == "true"
   puts("Skipping seeding data.")
   exit
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,11 +14,6 @@
 
 require "faker"
 
-if Rails.env.production?
-  puts("Seeding is disabled in production.")
-  exit
-end
-
 if ENV.fetch("SKIP_SEEDS", false) == "true"
   puts("Skipping seeding data.")
   exit


### PR DESCRIPTION
Modify the seeding logic to allow data seeding in production based on an environment variable, and update the handling of allowed request origins to prevent errors when the variable is not set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Seeding process now runs in all environments, enhancing flexibility.
	- Default pronouns set to "they/them" for new accounts.
	- At least 50 accounts will be created during seeding.
	- Tournament creation logic updated to ensure tournaments are published by default.
	- Pokémon data seeding now includes validation checks for species and position attributes.

- **Bug Fixes**
	- Improved error handling for Pokémon data validation. 

- **Configuration Updates**
	- Enhanced Action Cable configuration to prevent potential errors in production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->